### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "react-native-web": "0.0.49",
+    "react-native-web": "0.0.57",
     "react": "15.3.2",
     "url-loader": "0.5.7"
   },


### PR DESCRIPTION
Running `npm install` provoked: 
```
npm WARN react-dom@15.4.1 requires a peer of react@^15.4.1 but none was installed.
```

Running install with the updated the react-native-web version does not provoke the warning.