### PR TITLE
Babel should compile all react-native libraries in node_modules

### DIFF
--- a/web/webpack.config.dev.js
+++ b/web/webpack.config.dev.js
@@ -19,6 +19,13 @@ module.exports = {
         ]
       },
       {
+        // Most react-native libraries include uncompiled ES6 JS.
+        test: /\.js$/,
+        include: /node_modules\/react-native-/,
+        loader: 'babel-loader',
+        query: { cacheDirectory: true }
+      },
+      {
         test: /\.(gif|jpe?g|png|svg)$/,
         loader: 'url-loader',
         query: { name: '[name].[hash:16].[ext]' }


### PR DESCRIPTION
This is another small tweak that will help a lot of people get started with `react-native-web`. Most `react-native-*` libraries don't compile their JavaScript when they publish the package, so I think it's a good default to compile any libraries that start with `react-native-`.